### PR TITLE
Update Debian.yaml

### DIFF
--- a/openssh/parameters/os_family/Debian.yaml
+++ b/openssh/parameters/os_family/Debian.yaml
@@ -14,6 +14,9 @@ values:
     server: openssh-server
     client: openssh-client
     service: ssh
+    {%- if salt['config.get']('osrelease')|int > 12 %}
+    dig_pkg: bind9-dnsutils
+    {%- endif %}
   sshd_config:
     Subsystem: sftp /usr/lib/openssh/sftp-server
 ...


### PR DESCRIPTION
update dnsutils in case we are on debian13

the package dnsutils is deprecated and replaced by bind9-dnsutils since debian 13 (trixie)